### PR TITLE
Updating ClientValidator to public

### DIFF
--- a/src/NClient/NClient.Standalone/ClientProxy/Building/NClientOptionalBuilder.cs
+++ b/src/NClient/NClient.Standalone/ClientProxy/Building/NClientOptionalBuilder.cs
@@ -27,20 +27,16 @@ namespace NClient.Standalone.ClientProxy.Building
         where TClient : class
     {
         private readonly BuilderContext<TRequest, TResponse> _context;
-        private readonly SingletonProxyGeneratorProvider _proxyGeneratorProvider;
         private readonly IClientInterceptorFactory _clientInterceptorFactory;
         private readonly IClientProxyGenerator _clientProxyGenerator;
-        private readonly ClientValidator<TRequest, TResponse> _clientValidator;
         private readonly IPipelineCanceller _pipelineCanceler;
         public NClientOptionalBuilder(BuilderContext<TRequest, TResponse> context)
         {
             _context = context;
-            _proxyGeneratorProvider = new SingletonProxyGeneratorProvider();
-            _clientInterceptorFactory = new ClientInterceptorFactory(_proxyGeneratorProvider.Value);
-            _clientProxyGenerator = new ClientProxyGenerator(_proxyGeneratorProvider.Value, new ClientValidationExceptionFactory());
-            _clientValidator = new ClientValidator<TRequest, TResponse>(_proxyGeneratorProvider.Value, 
-                _clientInterceptorFactory, 
-                context);
+            
+            var proxyGeneratorProvider = new SingletonProxyGeneratorProvider();
+            _clientInterceptorFactory = new ClientInterceptorFactory(proxyGeneratorProvider.Value);
+            _clientProxyGenerator = new ClientProxyGenerator(proxyGeneratorProvider.Value, new ClientValidationExceptionFactory());
             _pipelineCanceler = new PipelineCanceller();
         }
 
@@ -177,7 +173,6 @@ namespace NClient.Standalone.ClientProxy.Building
         public TClient Build()
         {
             _context.EnsureComplete();
-            _clientValidator.Ensure<TClient>();
             
             var interceptor = _clientInterceptorFactory.Create<TClient, TRequest, TResponse>(_context, _pipelineCanceler);
             return _clientProxyGenerator.CreateClient<TClient>(interceptor);

--- a/src/NClient/NClient.Standalone/ClientProxy/Validation/ClientValidator.cs
+++ b/src/NClient/NClient.Standalone/ClientProxy/Validation/ClientValidator.cs
@@ -28,6 +28,9 @@ namespace NClient.Standalone.ClientProxy.Validation
             where TClient : class;
     }
 
+    /// <summary>
+    /// Validator used to check if a client matches the needed attribute usage in order to build a client
+    /// </summary>
     public class ClientValidator : IClientValidator
     {
         private static readonly Uri FakeHost = new("http://localhost:5000");
@@ -62,6 +65,11 @@ namespace NClient.Standalone.ClientProxy.Validation
                 .WithResponseValidation(new[] { new StubResponseValidatorProvider<IRequest, IResponse>() });
         }
 
+        /// <summary>
+        /// Checks the given TClient to see if it uses the appropriate attributes in order to successfully
+        /// build a client.
+        /// </summary>
+        /// <typeparam name="TClient"></typeparam>
         public void Ensure<TClient>()
             where TClient : class
         {

--- a/src/NClient/NClient.Standalone/NClient.Standalone.csproj
+++ b/src/NClient/NClient.Standalone/NClient.Standalone.csproj
@@ -28,6 +28,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\NClient.Providers\NClient.Providers.Api.Rest\NClient.Providers.Api.Rest.csproj" />
         <ProjectReference Include="..\NClient.Abstractions\NClient.Abstractions.csproj" />
         <ProjectReference Include="..\NClient.Annotations\NClient.Annotations.csproj" />
         <ProjectReference Include="..\NClient.Core\NClient.Core.csproj" />

--- a/tests/NClient/NClient.Standalone.Tests/Validation/ClientValidatorTest.cs
+++ b/tests/NClient/NClient.Standalone.Tests/Validation/ClientValidatorTest.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using NClient.Testing.Common.Clients;
 using System.Linq;
 using NClient.Exceptions;
+using NClient.Standalone.ClientProxy.Validation;
 
 namespace NClient.Standalone.Tests.Validation
 {
@@ -13,8 +14,8 @@ namespace NClient.Standalone.Tests.Validation
     [SuppressMessage("ReSharper", "BadDeclarationBracesLineBreaks")]
     public class ClientValidatorTest
     {
-        private readonly Uri _uri = new("http://localhost:5000");
-
+        private readonly ClientValidator _validator = new();
+        
         public interface IHiddenMyClient : IMyController
         {
             [GetMethod()]
@@ -51,25 +52,22 @@ namespace NClient.Standalone.Tests.Validation
         [Test]
         public void ClientValidator_WhenExecutingAnyInvalidMethodOnTheType_BuildThrows()
         {
-            var optsBuilder = NClientGallery.Clients.GetRest().For<IMyClientNoParentType>(host: _uri);
-            Func<IMyClientNoParentType> buildFunc = () => optsBuilder.Build();
-            buildFunc.Should().Throw<ClientValidationException>();
+            Action ax = () => _validator.Ensure<IMyClientNoParentType>();
+            ax.Should().Throw<ClientValidationException>();
         }
 
         [Test]
         public void ClientValidator_WhenExecutingHiddenMethodOnTheChildType_InvalidParentNotCheckedNoThrow()
         {
-            var optsBuilder = NClientGallery.Clients.GetRest().For<IReturnClientWithMetadata>(host: _uri);
-            Func<IReturnClientWithMetadata> buildFunc = () => optsBuilder.Build();
-            buildFunc.Should().NotThrow<Exception>();
+            Action ax = () => _validator.Ensure<IReturnClientWithMetadata>();
+            ax.Should().NotThrow<Exception>();
         }
 
         [Test]
         public void ClientValidator_WhenExecutingHiddenMethodOnTheChildType_OnlyChildMethodIsValidatedNoThrow()
         {
-            var optsBuilder = NClientGallery.Clients.GetRest().For<IHiddenMyClient>(host: _uri);
-            Func<IHiddenMyClient> buildFunc = () => optsBuilder.Build();
-            buildFunc.Should().NotThrow<Exception>();
+            Action ax = () => _validator.Ensure<IHiddenMyClient>();
+            ax.Should().NotThrow<Exception>();
         }
 
         [Test]


### PR DESCRIPTION
# Description

As described in issue #216 , the ClientValidator has been made public so it can be used to validate clients outside of the build step.  As part of this change, that validation step has been removed from 'build'.

Unit tests have been udpated to reflect this change.
